### PR TITLE
fix: remove blank space if no fullCalendar

### DIFF
--- a/lib/src/calendar_slider.dart
+++ b/lib/src/calendar_slider.dart
@@ -270,7 +270,7 @@ class CalendarSliderState extends State<CalendarSlider>
 
     return SizedBox(
       width: MediaQuery.of(context).size.width,
-      height: 180,
+      height: 180 - (widget.fullCalendar! ? 0 : widget.selectedTileHeight),
       child: Stack(
         children: [
           Positioned(


### PR DESCRIPTION
If you disable the `fullCalendar` there's a big gap/spacing above the slider. This PR is simply removing the gap.